### PR TITLE
Add ecarup active-charging API support

### DIFF
--- a/ecarupApiExamples/ecarupGrpcWebExample/Client/Pages/Index.razor
+++ b/ecarupApiExamples/ecarupGrpcWebExample/Client/Pages/Index.razor
@@ -11,7 +11,7 @@
 
 
 <MudContainer>  
-  
+
     <AuthorizeView>
         <NotAuthorized>
             <MudText Typo="Typo.h3">Please login</MudText>
@@ -20,7 +20,7 @@
         <Authorized>
             <MudText Typo="Typo.h3">ecarup connectors</MudText>
 
-             <MudTable Items="@Connectors" Context="connector" Hover="true" Loading="@_loading" LoadingProgressColor="Color.Info">
+            <MudTable Items="@Connectors" Context="connector" Hover="true" Loading="@_loading" LoadingProgressColor="Color.Info">
                 <HeaderContent>
                     <MudTh>Station Name</MudTh>
                     <MudTh>Connector Name</MudTh>
@@ -34,6 +34,26 @@
                 </PagerContent>
             </MudTable>
 
+
+            <MudText Typo="Typo.h3">Active chargings</MudText>
+            <MudTable Items="@ActiveChargings" Context="charging" Hover="true" Loading="@_loading" LoadingProgressColor="Color.Info">
+                <HeaderContent>
+                    <MudTh>Station</MudTh>
+                    <MudTh>DriverIdentifier</MudTh>
+                    <MudTh>Status</MudTh>
+                    <MudTh>Duration (s)</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Station">@GetConnectorName(charging)</MudTd>
+                    <MudTd DataLabel="DriverIdentifier">@charging.DriverIdentifier</MudTd>
+                    <MudTd DataLabel="Status">@charging.Status</MudTd>
+                    <MudTd DataLabel="Duration">@charging.Duration.Seconds</MudTd>
+                </RowTemplate>
+                <PagerContent>
+                    <MudTablePager PageSizeOptions="new int[] { 10, 25, 50, 100, int.MaxValue }" />
+                </PagerContent>
+            </MudTable>
+
         </Authorized>
     </AuthorizeView>
 </MudContainer>
@@ -42,6 +62,7 @@
 
 @code {
     private IEnumerable<ConnectorDto> Connectors = new List<ConnectorDto>();
+    private List<ActiveChargingDto> ActiveChargings = new List<ActiveChargingDto>();
 
     private bool _loading;
 
@@ -55,5 +76,38 @@
     private async Task LoadStations()
     {
         Connectors = await ConnectorsServiceFacade.GetAll();
-    }  
+        await LoadActiveChargingsForConnectors();
+    }
+
+    private string GetConnectorName(ActiveChargingDto activeChargingDto)
+    {
+        var connector = Connectors.FirstOrDefault(c => 
+            c.StationId == activeChargingDto.StationId &&
+            c.ConnectorId == activeChargingDto.ConnectorId);
+        return $"{connector?.StationName} {connector?.ConnectorName}";
+    }
+
+
+    private async Task LoadActiveChargingsForConnectors()
+    {
+        foreach (var connector in Connectors)
+        {
+            try
+            {
+                var request = new GetActiveChargingRequestDto
+                    {
+                        StationId = connector.StationId,
+                        ConnectorId = connector.ConnectorId
+                    };
+
+                var activeChargings = await ConnectorsServiceFacade.GetActiveChargingForConnector(request);
+                ActiveChargings.Add(activeChargings);
+            }
+            catch (Exception)
+            {
+                // Ignore the exception here. It will throw one if we don't have a charging for the connector
+            }
+        }
+    }
 }
+    

--- a/ecarupApiExamples/ecarupGrpcWebExample/Contract/ecarup/ActiveChargingDto.cs
+++ b/ecarupApiExamples/ecarupGrpcWebExample/Contract/ecarup/ActiveChargingDto.cs
@@ -1,0 +1,26 @@
+﻿using ProtoBuf;
+
+namespace ecarupGrpcWebExample.Contract.ecarup
+{
+    [ProtoContract]
+    public class ActiveChargingDto
+    {
+        [ProtoMember(1)]
+        public required string Id { get; set; }
+
+        [ProtoMember(2)]
+        public required string StationId { get; set; }
+
+        [ProtoMember(3)]
+        public required string ConnectorId { get; set; }
+
+        [ProtoMember(4)]
+        public required string DriverIdentifier { get; set; }
+
+        [ProtoMember(5)]
+        public required string Status { get; set; }
+
+        [ProtoMember(6)]
+        public required TimeSpan Duration { get; set; }
+    }
+}

--- a/ecarupApiExamples/ecarupGrpcWebExample/Contract/ecarup/GetActiveChargingRequestDto.cs
+++ b/ecarupApiExamples/ecarupGrpcWebExample/Contract/ecarup/GetActiveChargingRequestDto.cs
@@ -1,0 +1,14 @@
+﻿using ProtoBuf;
+
+namespace ecarupGrpcWebExample.Contract.ecarup
+{
+    [ProtoContract]
+    public class GetActiveChargingRequestDto
+    {
+        [ProtoMember(1)]
+        public required string StationId { get; set; }
+
+        [ProtoMember(2)]
+        public required string ConnectorId { get; set; }
+    }
+}

--- a/ecarupApiExamples/ecarupGrpcWebExample/Contract/ecarup/IConnectorService.cs
+++ b/ecarupApiExamples/ecarupGrpcWebExample/Contract/ecarup/IConnectorService.cs
@@ -8,5 +8,8 @@ namespace ecarupGrpcWebExample.Contract.ecarup
     {
         [Operation]
         Task<IEnumerable<ConnectorDto>> GetAll(CallContext context = default);
+
+        [Operation]
+        Task<ActiveChargingDto> GetActiveChargingForConnector(GetActiveChargingRequestDto request, CallContext context = default);
     }
 }

--- a/ecarupApiExamples/ecarupGrpcWebExample/Server/ecarupApi/EcarupApiGrpcClient.cs
+++ b/ecarupApiExamples/ecarupGrpcWebExample/Server/ecarupApi/EcarupApiGrpcClient.cs
@@ -1,5 +1,6 @@
 ﻿using Grpc.Core;
 using Grpc.Net.Client;
+using PublicApi.ActiveChargings;
 using PublicApi.ChargingHistory;
 using PublicApi.Stations;
 using System.Net.Http.Headers;
@@ -8,6 +9,8 @@ namespace ecarupGrpcWebExample.Server.ecarupApi
 {
     public class EcarupApiGrpcClient
     {
+        const string BaseUrl = "https://public-api.ecarup.com";
+
         public async Task<StationsReply> GetAllStations(string accessToken)
         {
             var customHttpClient = new HttpClient();
@@ -18,7 +21,7 @@ namespace ecarupGrpcWebExample.Server.ecarupApi
                 HttpClient = customHttpClient
             };
 
-            using var channel = GrpcChannel.ForAddress("https://public-api.ecarup.com", options);
+            using var channel = GrpcChannel.ForAddress(BaseUrl, options);
             var client = new StationProtoService.StationProtoServiceClient(channel);
 
             var reuqest = new GetAllStationsRequest()
@@ -27,6 +30,31 @@ namespace ecarupGrpcWebExample.Server.ecarupApi
             };
 
             return await client.GetAllAsync(reuqest);
+        }
+
+        public async Task<ActiveChargingResponse> GetActiveChargingForConnector(
+            string accessToken,
+            string stationId,
+            string connectorId)
+        {
+            var customHttpClient = new HttpClient();
+            customHttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+            var options = new GrpcChannelOptions()
+            {
+                HttpClient = customHttpClient
+            };
+
+            using var channel = GrpcChannel.ForAddress(BaseUrl, options);
+            var client = new ActiveChargingProtoService.ActiveChargingProtoServiceClient(channel);
+
+            var reuqest = new GetForConnectorRequest()
+            {
+               StationId = stationId,
+               ConnectorId = connectorId
+            };
+
+            return await client.GetForConnectorAsync(reuqest);
         }
     }
 }

--- a/ecarupApiExamples/ecarupGrpcWebExample/Server/ecarupApi/protobuf/active_charging.proto
+++ b/ecarupApiExamples/ecarupGrpcWebExample/Server/ecarupApi/protobuf/active_charging.proto
@@ -1,0 +1,84 @@
+﻿syntax = "proto3";
+
+option csharp_namespace = "PublicApi.ActiveChargings";
+
+import "google/api/annotations.proto";
+import "google/api/timestamp.proto";
+
+package protos.activeCharging;
+
+service ActiveChargingProtoService {
+  rpc GetForConnector (GetForConnectorRequest) returns (ActiveChargingResponse) {
+    option (google.api.http) = {
+      get: "/v1/station/{station_id}/connectors/{connector_id}/active-charging"
+    };
+  }
+}
+
+message GetForConnectorRequest {
+  // ID of the station
+  string station_id = 1;
+
+  // ID of the connector
+  string connector_id = 2;
+}
+
+message ActiveChargingResponse {
+  // ID of the charging
+  string id = 1;
+
+  // ID of the user who started the charging
+  string driverIdentifier = 2;
+
+  // Status of the charging
+  ActiveChargingStatus status = 3;
+
+  // UTC time when the charging was started
+  google.protobuf.Timestamp start_time = 4;
+
+  // eCarUp internal meter value when the charging was started in Wh
+  double start_meter_value_wh = 5;
+
+  // Price for the user who started the charging
+  Price price = 6;
+
+  // transaction related information
+  optional Transaction transaction = 7;
+}
+
+message Price {
+  // Currency of the price
+  string currency = 1;
+
+  // Price for energy consumption per kWh
+  double consumptionPerKwh = 2;
+
+  // Price for duration of charging per hour
+  double timePerH = 3;
+}
+
+message Transaction {
+  // ID of the transaction
+  string transaction_id = 1;
+
+  // Meter start value the station sent with the StartTransaction
+  double meter_start_wh = 2;
+
+  // Meter stop value the station sent with the StopTransaction
+  optional double meter_stop_wh = 3;
+
+  // Last Power.Active.Import value the station sent
+  optional double meter_active_power_w = 4;
+
+  // Last Energy.Active.Import.Register value the station sent
+  optional double meter_active_energy_wh = 5;
+}
+
+enum ActiveChargingStatus
+{
+  // Charging is active
+  ACTIVE = 0;
+
+  // Charging has been deactivated and is pending
+  DEACTIVATION_PENDING = 1;
+}

--- a/ecarupApiExamples/ecarupGrpcWebExample/Server/ecarupGrpcWebExample.Server.csproj
+++ b/ecarupApiExamples/ecarupGrpcWebExample/Server/ecarupGrpcWebExample.Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="ecarupApi\protobuf\active_charging.proto" />
     <None Remove="ecarupApi\protobuf\charginghistory.proto" />
     <None Remove="ecarupApi\protobuf\station.proto" />
     <None Remove="google\api\annotations.proto" />
@@ -36,6 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Protobuf Include="ecarupApi\protobuf\active_charging.proto" GrpcServices="Client" />
     <Protobuf Include="ecarupApi\protobuf\charginghistory.proto" GrpcServices="Client" />
     <Protobuf Include="ecarupApi\protobuf\station.proto" GrpcServices="Client" />
     <Protobuf Include="google\api\annotations.proto" GrpcServices="Client" />


### PR DESCRIPTION
Support for the new ecarup **active charging** public API. 

A simple demo was added to get all active chargings for all connectors over the gRPC API. 

![image](https://github.com/user-attachments/assets/09372554-27b0-420e-bc8f-ce7cf1cdb5df)


**What you can test**

- Nothing. It's just a demo how to use the new active charging api